### PR TITLE
Fix footer to stay pinned at bottom on all pages

### DIFF
--- a/2025.html
+++ b/2025.html
@@ -205,7 +205,7 @@
         </section>
         <!-- /All Sponsors Section -->
     </main>
-    <footer class="text-center py-3 my-1">
+    <footer class="text-center py-3 fixed-bottom">
         <p>&copy; 2025 Skate or Die Punk Fest <a href="mailto:skateordiepunkfest@gmail.com">skateordiepunkfest@gmail.com</a></p>
     </footer>
     <script src="script.js"></script>

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <main class="container-fluid d-flex justify-content-center align-items-start py-4 px-2 px-md-4">
         <img src="flyer2026.svg" alt="Skate or Die Punk Fest 2026 Flyer" class="img-fluid flyer2026-img">
     </main>
-    <footer class="text-center py-3 my-1">
+    <footer class="text-center py-3 fixed-bottom">
         <p>&copy; 2025 Skate or Die Punk Fest <a href="mailto:skateordiepunkfest@gmail.com">skateordiepunkfest@gmail.com</a></p>
     </footer>
     <script src="script.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -7,10 +7,8 @@ body {
     font-family: "Libertinus Mono", monospace;
     margin: 0;
     padding: 0;
+    padding-bottom: 4rem;
     color: #222;
-    display: flex;
-    flex-direction: column;
-    min-height: 100vh;
     background: #C6D7EF url('skateordiebackgroundimage.svg') no-repeat center center;
     background-size: cover;
 }
@@ -24,7 +22,6 @@ footer {
 
 main {
     margin: 0 auto;
-    flex: 1;
 }
 
 section {


### PR DESCRIPTION
## Why

The footer previously relied on a flexbox "push down" trick (`min-height: 100vh` on `body` plus `flex: 1` on `main`) to sit at the bottom of the page. This depended on content height calculations that felt unreliable across different screen sizes, and the footer markup/behavior wasn't guaranteed to match consistently between `index.html` and `2025.html`.

## Approach

- Added Bootstrap's `fixed-bottom` utility class to the `<footer>` on both `index.html` and `2025.html`, so the footer is always fixed to the bottom of the viewport regardless of content height, using the same markup on both pages.
- Removed the now-unnecessary flexbox height-calc styles from `styles.css` (`display: flex`, `flex-direction: column`, `min-height: 100vh` on `body`; `flex: 1` on `main`).
- Added `padding-bottom: 4rem` to `body` so page content never gets hidden behind the fixed footer.

Verified with local screenshots on both pages that the footer stays fixed at the bottom and page content remains fully visible above it.